### PR TITLE
Fix ZIP display bug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
     #     # brew update
     #     brew install pkg-config
     #     brew upgrade
+
+    - name: Install Ninja
+      run: brew install ninja
     
     - name: Configure CMake
       run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
       
   build-macos:
-    runs-on: [macos-latest]
+    runs-on: [macos-13] # avoid ARM for now - https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources 
     steps:
     - uses: actions/checkout@v2
       with:
@@ -38,9 +38,6 @@ jobs:
     #     # brew update
     #     brew install pkg-config
     #     brew upgrade
-
-    - name: Install Ninja
-      run: brew install ninja
     
     - name: Configure CMake
       run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}

--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -63,7 +63,7 @@ jobs:
         retention-days: 1
      
   build-macos:
-    runs-on: [macos-latest]
+    runs-on: [macos-13] # avoid ARM for now - https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources 
     steps:
     - uses: actions/checkout@v2
       with:

--- a/Types/ZIP/src/ZIPFile.cpp
+++ b/Types/ZIP/src/ZIPFile.cpp
@@ -71,7 +71,7 @@ bool ZIPFile::BeginIteration(std::u16string_view path, AppCUI::Controls::TreeVie
         CHECK(usb.Set(filename), false, "");
 
         const auto sv = usb.ToStringView();
-        if (sv.size() != path.size() && sv.starts_with(path)) {
+        if (sv.size() > path.size() && sv.starts_with(path) && sv[path.size()] == '/') {
             const auto tmpSV = std::u16string_view{ sv.data() + path.size(), sv.size() - path.size() };
             if (tmpSV.find_first_of('/') == tmpSV.find_last_of('/')) {
                 curentChildIndexes.push_back(i);
@@ -205,7 +205,7 @@ class PasswordDialog : public Window, public Handlers::OnButtonPressedInterface
 };
 
 void ZIPFile::OnOpenItem(std::u16string_view path, AppCUI::Controls::TreeViewItem item)
-{
+    {
     CHECKRET(item.GetParent().GetHandle() != InvalidItemHandle, "");
 
     const auto index = item.GetData(-1);

--- a/Types/ZIP/src/ZIPFile.cpp
+++ b/Types/ZIP/src/ZIPFile.cpp
@@ -205,7 +205,7 @@ class PasswordDialog : public Window, public Handlers::OnButtonPressedInterface
 };
 
 void ZIPFile::OnOpenItem(std::u16string_view path, AppCUI::Controls::TreeViewItem item)
-    {
+{
     CHECKRET(item.GetParent().GetHandle() != InvalidItemHandle, "");
 
     const auto index = item.GetData(-1);


### PR DESCRIPTION
Fixed 2 issues:
- we can now support ZIPs that don't have the parent directory as a standalone entry
- ensure the displayed files actually belong to the shown directory - before, the only check was that the parent directory is a prefix of the file's path, but this is insufficient