### PR TITLE
Added GutHub build attestation

### DIFF
--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -61,6 +61,12 @@ jobs:
         name: windows_artifacts
         path: "GView-${{ runner.os }}-${{runner.arch}}-${{ env.GVIEW_VERSION }}.zip"
         retention-days: 1
+
+    - name: Generate signed build provenance
+      uses: actions/attest-build-provenance@v2
+      with:
+        subject-name: GView-${{ runner.os }}-${{runner.arch}}-${{ env.GVIEW_VERSION }}.zip
+        subject-digest: sha256:${{ steps.upload.outputs.artifact-digest }}
      
   build-macos:
     runs-on: [macos-13] # avoid ARM for now - https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources 
@@ -111,6 +117,12 @@ jobs:
         name: apple_artifacts
         path: "/Users/runner/work/GView/GView/bin/Release/GView-${{ runner.os }}-${{runner.arch}}-${{ env.GVIEW_VERSION }}.zip"
         retention-days: 1
+
+    - name: Generate signed build provenance
+      uses: actions/attest-build-provenance@v2
+      with:
+        subject-name: GView-${{ runner.os }}-${{runner.arch}}-${{ env.GVIEW_VERSION }}.zip
+        subject-digest: sha256:${{ steps.upload.outputs.artifact-digest }}
         
   build-ubuntu:
     runs-on: [ubuntu-20.04]
@@ -165,6 +177,12 @@ jobs:
         name: linux_artifacts
         path: "/home/runner/work/GView/GView/bin/Release/GView-${{ runner.os }}-${{runner.arch}}-${{ env.GVIEW_VERSION }}.zip"
         retention-days: 1     
+
+    - name: Generate signed build provenance
+      uses: actions/attest-build-provenance@v2
+      with:
+        subject-name: GView-${{ runner.os }}-${{runner.arch}}-${{ env.GVIEW_VERSION }}.zip
+        subject-digest: sha256:${{ steps.upload.outputs.artifact-digest }}
       
   publish_job:
     name: "Publish to release"

--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -1,5 +1,9 @@
 name: "Deploy release"
 
+permissions:
+  id-token: write
+  attestations: write
+
 on:
   push:
     branches:

--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -124,7 +124,7 @@ jobs:
     - name: Generate signed build provenance
       uses: actions/attest-build-provenance@v2
       with:
-        subject-path: GView-${{ runner.os }}-${{runner.arch}}-${{ env.GVIEW_VERSION }}.zip
+        subject-path: "/Users/runner/work/GView/GView/bin/Release/GView-${{ runner.os }}-${{runner.arch}}-${{ env.GVIEW_VERSION }}.zip"
         
   build-ubuntu:
     runs-on: [ubuntu-20.04]
@@ -183,7 +183,7 @@ jobs:
     - name: Generate signed build provenance
       uses: actions/attest-build-provenance@v2
       with:
-        subject-path: GView-${{ runner.os }}-${{runner.arch}}-${{ env.GVIEW_VERSION }}.zip
+        subject-path: "/home/runner/work/GView/GView/bin/Release/GView-${{ runner.os }}-${{runner.arch}}-${{ env.GVIEW_VERSION }}.zip"
       
   publish_job:
     name: "Publish to release"

--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -69,8 +69,7 @@ jobs:
     - name: Generate signed build provenance
       uses: actions/attest-build-provenance@v2
       with:
-        subject-name: GView-${{ runner.os }}-${{runner.arch}}-${{ env.GVIEW_VERSION }}.zip
-        subject-digest: sha256:${{ steps.upload.outputs.artifact-digest }}
+        subject-path: GView-${{ runner.os }}-${{runner.arch}}-${{ env.GVIEW_VERSION }}.zip
      
   build-macos:
     runs-on: [macos-13] # avoid ARM for now - https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources 
@@ -125,8 +124,7 @@ jobs:
     - name: Generate signed build provenance
       uses: actions/attest-build-provenance@v2
       with:
-        subject-name: GView-${{ runner.os }}-${{runner.arch}}-${{ env.GVIEW_VERSION }}.zip
-        subject-digest: sha256:${{ steps.upload.outputs.artifact-digest }}
+        subject-path: GView-${{ runner.os }}-${{runner.arch}}-${{ env.GVIEW_VERSION }}.zip
         
   build-ubuntu:
     runs-on: [ubuntu-20.04]
@@ -185,8 +183,7 @@ jobs:
     - name: Generate signed build provenance
       uses: actions/attest-build-provenance@v2
       with:
-        subject-name: GView-${{ runner.os }}-${{runner.arch}}-${{ env.GVIEW_VERSION }}.zip
-        subject-digest: sha256:${{ steps.upload.outputs.artifact-digest }}
+        subject-path: GView-${{ runner.os }}-${{runner.arch}}-${{ env.GVIEW_VERSION }}.zip
       
   publish_job:
     name: "Publish to release"


### PR DESCRIPTION
Build attestation is way to guarantee that artifacts are built on GitGub workers and are not modified by anyone: [documentation link](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds).

Example attestation generated for GView-Windows-X64-0.360.0.zip: [link](https://github.com/rzaharia/GView/attestations/4741126)